### PR TITLE
docs(readme): forgot to allcaps coc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository stores default GitHub templates and community health files
 for all repositories under `peer-network`. Any repo that doesn't provide its own 
 templates will inherit from here.
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 


### PR DESCRIPTION
the link in the readme did not work because i forgot that the file name must be in all caps.
