### PR TITLE
Release 1.1.0 of Peers git guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,49 +2,8 @@
 
 This guide outlines the collaborative workflow for contributing to this repository. Follow these steps to ensure smooth collaboration and code integration.  
 
----
-
-## 📛 Naming Conventions (Branches & Commits)  
-
-### **Branch Names**  
-Follow the format:  
-`<username>/<type>/<short-description>`  
-
-**Examples:**  
-```bash  
-git checkout -b jakob/feat/user-auth      # Feature branch  
-git checkout -b lena/fix/header-overflow  # Bug fix branch  
-git checkout -b max/docs/contributing     # Documentation update  
-```  
-
-**Accepted Types:**  
-- `feat/`: New features or functionality.  
-- `fix/`: Bug fixes or patches.  
-- `docs/`: Documentation changes.  
-- `chore/`: Maintenance tasks (e.g., CI/CD, dependency updates).  
-- `test/`: Adding or updating tests.  
-- `refactor/`: Code restructuring (no new features/fixes).  
-
-**Rules:**  
-- Always Branch from the **development** branch!  
-- Only use lower case letters.  
-- Try holding the Branchnames short and descriptiv.  
----
-
-### **Commit Messages**  
-`<type>(<scope>): <subject>`  
-
-**Examples:**  
-```bash  
-git commit -m "feat(auth): add OAuth2 login support"  
-git commit -m "fix(header): resolve mobile overflow"  
-git commit -m "docs(readme): update contribution guide"  
-```  
-
-**Rules:**  
-- Use the **imperative mood** ("add" instead of "added").  
-- Try to keep the subject line under **50 characters**.  
-
+For our naming conventions and commit-/ branch-rules please check out:
+[![GIT_GUIDELINES](https://img.shields.io/badge/GIT-Guidelines-blue.svg)](GIT_GUIDELINES.md)
 ---
 
 ## 🛠️ Getting Started  
@@ -99,15 +58,7 @@ git push origin your-username/type/short-description
 
 1. Navigate to the repository on GitHub (the main repo if you’re internal, or your fork if external).  
 2. Click **"Compare & pull request"** for your newly pushed branch.  
-3. Provide a **clear title** and **detailed description** explaining:  
-   - The purpose of your changes.  
-   - Any issues or features addressed.  
-   - Additional context for reviewers.  
-
-### 🔍 PR Best Practices  
-- **Keep PRs focused**: Address one feature/bug per pull request.  
-- **Tag relevant reviewers**: Use `@mentions` to notify team members.  
-- **Respond to feedback**: Discuss suggestions in the PR’s comment section.  
+3. Provide a **clear title** and **detailed description** (see [![GIT_GUIDELINES](https://img.shields.io/badge/GIT-Guidelines-blue.svg)](GIT_GUIDELINES.md) for more details)
 
 ---
 
@@ -142,8 +93,7 @@ Resolve any conflicts that come up and test your changes to ensure everything st
 
 - **Review Process**: The lead developer or team will review your changes.  
 - **Resolve Feedback**: Update your branch if revisions are requested.  
-- **Merge or Close**: Once approved, the PR will be merged into main by the lead developer or maintainers. If the changes are deemed unnecessary, it may be closed.  
-
+- **Merge or Close**: Once approved, the PR will be merged and the branch should be removed afterwards.
 ---
 
 ## 🧹 Branch Cleanup Best Practices  
@@ -159,7 +109,6 @@ Resolve any conflicts that come up and test your changes to ensure everything st
 2. **Exceptions (When to Keep Branches):**  
    - 🌿 **Long-term branches**: E.g., `dev`, `staging`, or version-specific branches like `v2.0`.  
    - 🛠️ **Ongoing work**: Branches tied to multi-PR features still in progress.  
-   - 🏷️ **Tagged releases**: Branches associated with specific releases (e.g., `release-1.3.0`).  
 
 ---
 
@@ -183,15 +132,10 @@ git push origin --delete branch_name
 
 ## 💡 Tips for Effective Collaboration  
 
-- **Sync Frequently**: Regularly pull the latest `main` branch to avoid conflicts:  
-  ```bash  
-  git checkout main  
-  git pull origin main  
-  ```  
 - **Write Clear Commit Messages**: Explain the **why**, not just the *what*.  
 - **Test Locally**: Verify changes work before submitting a PR.  
 
 ---
 
 **Happy Coding!** 🎉  
-Let’s build something amazing together. For advanced workflows, refer to [GitHub’s Collaboration Guide](https://docs.github.com/en/get-started/quickstart/github-flow).  
+Let’s build something amazing together.

--- a/GIT_GUIDELINES.md
+++ b/GIT_GUIDELINES.md
@@ -1,0 +1,112 @@
+# Git Workflow Reference (Company Standard)
+
+The Goal of this doc is it to synchronize the Repos of all the Peer Departments. It complements each repo’s `CONTRIBUTING.md` and keeps day‑to‑day work consistent across teams.
+
+For some more guidelines about how to use Git (commands) refer to this page:
+[![Contributing](https://img.shields.io/badge/Contributing-Guidelines-blue.svg)](CONTRIBUTING.md)
+---
+
+## Branch Model (Two Stable Branches + Short‑Lived Work Branches)
+
+**Stable branches**
+- **`main`** — always points to the **current released production** version.
+- **`development`** — integration branch for the **current dev/testing** build.
+
+**Short‑lived branches** (create off `development` only):
+- `username/feat/<short-desc>` — new features
+- `username/fix/<short-desc>` — bug fixes
+- `username/docs/<short-desc>` — documentation
+- `username/refactor/<short-desc>` — restructurings
+- `username/test/<short-desc>` — tests
+- `username/chore/<short-desc>` — tooling/CI/deps
+
+> Keep names lowercase, short, and descriptive.
+
+### Visual: Typical Flow
+```
+   (releases)
+      |        |
+      v        v
+-----●---------●--------------------  main (releases only)
+         \      \
+          \      \ (merge via PR w/ release version + notes)
+           \      ●------------------  development (integrate & test)
+            \    /
+             ●--●   short‑lived branches (feat/fix/docs/…)
+                \
+                 ●  done -> PR into development -> delete branch
+```
+
+---
+
+## What May Update Each Branch
+
+- **`main`**
+  - **Only** via a **Pull Request from `development`**.
+  - PR **must state the release version** (for example, `Release 1.3.0`) and include **release notes** (changelog + any extra info).
+
+- **`development`**
+  - **Only** via **PRs from short‑lived branches** (`feat/`, `fix/`, `docs/`, etc.).
+  - Each PR must briefly describe **what changes**, **why** and **link to the related ClickUp task ID or URL**.
+
+
+---
+
+## Commit Policy
+
+- Commit **small-ish, focused changes**.
+- **Commit only to short‑lived branches** (never directly to `main` or `development`).
+- Use **clear, short subjects** in imperative mood.
+- **Daily safety snapshot**: at **end of your workday**, add a final commit labeled **WIP** to store progress.
+
+### Recommended commit style
+Use Conventional-style messages:
+```
+<type>(<optional-scope>): <short subject>
+
+[optional body]
+```
+**Types**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+**Examples**
+```
+feat(auth): add OAuth2 login
+fix(header): resolve mobile overflow
+docs(readme): clarify setup steps
+chore: update CI cache key
+chore: WIP — end of day snapshot (2025-11-11)
+```
+
+> Keep subjects ≲ 50 chars; explain the **why** in the body when helpful.
+
+---
+
+## Pull Requests (PRs)
+
+**From short‑lived branch → `development`**
+- Title: concise summary (e.g., `feat: profile privacy controls`).
+- Description: **What/Why/How**, screenshots if UI, test notes, and any risks (only if helpfull).
+- Link tickets/issues, especially the **ClickUp task link or ID**.
+- Assign reviewers and request review early if feedback is needed.
+
+**From `development` → `main` (Release PR)**
+- Title: `Release X.Y.Z`
+- Description must include **Release Notes**:
+  - Added / Changed / Fixed / Removed
+  - Migrations/ops steps
+  - Known issues
+
+### Minimal PR template
+```
+## Summary
+Short explanation of the change.
+
+## Impact / Risks
+- ...
+
+## Links
+- ClickUp: [Task ID or URL]
+- ... (additional important/helpfull links)
+```
+
+

--- a/GIT_GUIDELINES.md
+++ b/GIT_GUIDELINES.md
@@ -54,7 +54,7 @@ For some more guidelines about how to use Git (commands) refer to this page:
 
 ## Commit Policy
 
-- Commit **small-ish, focused changes**.
+- Commit **small-ish, focused changes multiple times a day**.
 - **Commit only to short‑lived branches** (never directly to `main` or `development`).
 - Use **clear, short subjects** in imperative mood.
 - **Daily safety snapshot**: at **end of your workday**, add a final commit labeled **WIP** to store progress.
@@ -74,7 +74,7 @@ feat(auth): add OAuth2 login
 fix(header): resolve mobile overflow
 docs(readme): clarify setup steps
 chore: update CI cache key
-chore: WIP — end of day snapshot (2025-11-11)
+chore: WIP — end of day snapshot
 ```
 
 > Keep subjects ≲ 50 chars; explain the **why** in the body when helpful.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ templates will inherit from here.
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)  
 [![Contributing](https://img.shields.io/badge/Contributing-Guidelines-blue.svg)](CONTRIBUTING.md)
+[![GIT_GUIDELINES](https://img.shields.io/badge/GIT-Guidelines-blue.svg)](GIT_GUIDELINES.md)


### PR DESCRIPTION
Added a git_guidelines.md regarding naming conventions of commits and PRs and some basic rules -> when to commit, when to PR, ... 
I am hoping and trying for a more synchroinzed look and and feel of the whole Peer Project on github.
