### PR TITLE
Wisdom/feat/devops tracking

### DIFF
--- a/docs/devops-dashboard/dashboard.js
+++ b/docs/devops-dashboard/dashboard.js
@@ -1,0 +1,59 @@
+async function fetchJSON(url) {
+    try {
+        const res = await fetch(url);
+        if (!res.ok) {
+            console.warn("API Error:", url, res.status);
+            return null;
+        }
+        return await res.json();
+    } catch (err) {
+        console.error("Fetch failed:", url, err);
+        return null;
+    }
+}
+
+async function loadDashboard() {
+    document.getElementById("loading").style.display = "block";
+
+    const repos = [
+        "peer-network/peer_backend",
+        "peer-network/peer_web_frontend",
+        "peer-network/peer_android_frontend",
+        "peer-network/peer_rust_backend",
+        "peer-network/peer_cd",
+        "peer-network/.github",
+    ];
+
+    let totalOpenPRs = 0;
+    let totalFailures = 0;
+
+    for (const repo of repos) {
+        console.log("Fetching repo:", repo);
+
+        // --- OPEN PRs ---
+        const prs = await fetchJSON(`https://api.github.com/repos/${repo}/pulls?state=open`);
+        if (prs) totalOpenPRs += prs.length;
+
+        // --- FAILED CI RUNS ---
+        const runs = await fetchJSON(`https://api.github.com/repos/${repo}/actions/runs?per_page=50`);
+        if (runs?.workflow_runs) {
+            const failed = runs.workflow_runs.filter(r => r.conclusion === "failure").length;
+            totalFailures += failed;
+        }
+    }
+
+    // Update dashboard
+    document.getElementById("open-prs").innerText = totalOpenPRs;
+    document.getElementById("ci-failures").innerText = totalFailures;
+
+    // Placeholder values
+    document.getElementById("gitleaks-run").innerText = "Coming soon...";
+    document.getElementById("trivy-run").innerText = "Coming soon...";
+    document.getElementById("health-score").innerText = "Calculating...";
+
+    // Show UI
+    document.getElementById("loading").style.display = "none";
+    document.getElementById("dashboard").style.display = "block";
+}
+
+loadDashboard();

--- a/docs/devops-dashboard/index.html
+++ b/docs/devops-dashboard/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Peer Network — DevOps Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Peer Network — DevOps Dashboard</h1>
+
+<section id="loading">Loading data...</section>
+
+<section id="dashboard" style="display:none;">
+    <div class="card">
+        <h2>Total Open PRs</h2>
+        <div id="open-prs">--</div>
+    </div>
+
+    <div class="card">
+        <h2>Failed CI Runs (last 7 days)</h2>
+        <div id="ci-failures">--</div>
+    </div>
+
+    <div class="card">
+        <h2>Last Gitleaks Run</h2>
+        <div id="gitleaks-run">--</div>
+    </div>
+
+    <div class="card">
+        <h2>Last Trivy Run</h2>
+        <div id="trivy-run">--</div>
+    </div>
+
+    <div class="card">
+        <h2>Repo Health Score</h2>
+        <div id="health-score">--</div>
+    </div>
+</section>
+
+<script src="dashboard.js"></script>
+</body>
+</html>

--- a/docs/devops-dashboard/style.css
+++ b/docs/devops-dashboard/style.css
@@ -1,0 +1,23 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f6f7;
+  padding: 20px;
+}
+
+h1 {
+  font-size: 28px;
+  margin-bottom: 20px;
+}
+
+.card {
+  background: white;
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 8px rgba(0,0,0,0.1);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR introduces the first version of the Peer Network DevOps Dashboard.
The goal is to provide a simple central view of CI activity across all Peer Network repositories.
This will support upcoming DevOps maturity work by improving visibility and monitoring for failures and open PRs.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Added a lightweight GitHub Pages dashboard under docs/devops-dashboard/

Includes index.html, dashboard.js, and style.css

Dashboard currently displays:

Total open PR count across all repos

Recent CI failures 

Placeholders for Gitleaks, Trivy, and health score (to be completed next)

Designed for GitHub Pages hosting

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

New folder: docs/devops-dashboard/

Three new files:

index.html

dashboard.js

style.css

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

No impact on existing workflows.
Dashboard loads data client-side via public GitHub API.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
