### PR TITLE
Wisdom/feat/devops tracking

### DIFF
--- a/docs/devops-dashboard/dashboard.js
+++ b/docs/devops-dashboard/dashboard.js
@@ -1,5 +1,10 @@
 function badge(color, text) {
-    return `<span class="badge ${color}">${text}</span>`;
+    const icon =
+        color === "green" ? "🟩" :
+        color === "yellow" ? "🟨" :
+        "🟥";
+
+    return `<span class="badge ${color}">${icon} ${text}</span>`;
 }
 
 function computeHealth({ openPRs, failures, gitleaks, trivy, lastCI }) {
@@ -126,12 +131,13 @@ async function loadDashboard() {
         // --- Add row to table ---
         tableBody.innerHTML += `
             <tr>
-                <td>${repo}</td>
+                <td><a href="https://github.com/${repo}" target="_blank">${repo}</a></td>
                 <td>${info.openPRs}</td>
                 <td>${info.gitleaks ? new Date(info.gitleaks).toLocaleString() : badge("red","None")}</td>
                 <td>${info.trivy ? new Date(info.trivy).toLocaleString() : badge("red","None")}</td>
                 <td>${info.lastCI ? new Date(info.lastCI).toLocaleString() : "—"}</td>
                 <td>${badge(color, score)}</td>
+                <td><a href="https://github.com/${repo}/actions" target="_blank">🔗 View Actions</a></td>
             </tr>
         `;
     }

--- a/docs/devops-dashboard/dashboard.js
+++ b/docs/devops-dashboard/dashboard.js
@@ -1,3 +1,23 @@
+function badge(color, text) {
+    return `<span class="badge ${color}">${text}</span>`;
+}
+
+function computeHealth({ openPRs, failures, gitleaks, trivy, lastCI }) {
+    let score = 100;
+
+    if (openPRs > 8) score -= 10;
+    if (failures > 5) score -= 20;
+    if (!gitleaks) score -= 15;
+    if (!trivy) score -= 15;
+
+    if (!lastCI) score -= 10;
+
+    const ciAgeHours = (Date.now() - new Date(lastCI)) / 36e5;
+    if (ciAgeHours > 24) score -= 10;
+
+    return Math.max(score, 0);
+}
+
 async function fetchJSON(url) {
     try {
         const res = await fetch(url);
@@ -19,37 +39,115 @@ async function loadDashboard() {
         "peer-network/peer_backend",
         "peer-network/peer_web_frontend",
         "peer-network/peer_android_frontend",
+        "peer-network/peer_ios_frontend",
         "peer-network/peer_rust_backend",
         "peer-network/peer_cd",
+        "peer-network/peer_ansible",
         "peer-network/.github",
     ];
 
     let totalOpenPRs = 0;
     let totalFailures = 0;
+    let lastGitleaksDate = null;
+    let lastTrivyDate = null;
+
+    const tableBody = document.querySelector("#repo-table tbody");
 
     for (const repo of repos) {
-        console.log("Fetching repo:", repo);
+
+        // Per-repo object
+        const info = {
+            repo,
+            openPRs: 0,
+            failures: 0,
+            gitleaks: null,
+            trivy: null,
+            lastCI: null,
+        };
 
         // --- OPEN PRs ---
         const prs = await fetchJSON(`https://api.github.com/repos/${repo}/pulls?state=open`);
-        if (prs) totalOpenPRs += prs.length;
-
-        // --- FAILED CI RUNS ---
-        const runs = await fetchJSON(`https://api.github.com/repos/${repo}/actions/runs?per_page=50`);
-        if (runs?.workflow_runs) {
-            const failed = runs.workflow_runs.filter(r => r.conclusion === "failure").length;
-            totalFailures += failed;
+        if (prs) {
+            info.openPRs = prs.length;
+            totalOpenPRs += prs.length;
         }
+
+        // --- CI RUNS ---
+        const runs = await fetchJSON(`https://api.github.com/repos/${repo}/actions/runs?per_page=30`);
+        if (runs?.workflow_runs) {
+
+            const workflowRuns = runs.workflow_runs;
+
+            // failures
+            const failed = workflowRuns.filter(r => r.conclusion === "failure").length;
+            info.failures = failed;
+            totalFailures += failed;
+
+            // last CI
+            if (workflowRuns.length > 0) {
+                info.lastCI = workflowRuns[0].created_at;
+            }
+
+            // gitleaks
+            const gRun = workflowRuns.find(r =>
+                r.name?.toLowerCase().includes("gitleaks") ||
+                r.display_title?.toLowerCase().includes("gitleaks")
+            );
+            info.gitleaks = gRun?.created_at || null;
+
+            // trivy
+            const tRun = workflowRuns.find(r =>
+                r.name?.toLowerCase().includes("trivy") ||
+                r.display_title?.toLowerCase().includes("trivy")
+            );
+            info.trivy = tRun?.created_at || null;
+
+            // --- Track org-wide latest Gitleaks run ---
+            if (info.gitleaks) {
+                const d = new Date(info.gitleaks);
+                if (!lastGitleaksDate || d > lastGitleaksDate) {
+                    lastGitleaksDate = d;
+                }
+            }
+
+            // --- Track org-wide latest Trivy run ---
+            if (info.trivy) {
+                const d = new Date(info.trivy);
+                if (!lastTrivyDate || d > lastTrivyDate) {
+                    lastTrivyDate = d;
+                }
+            }
+        }
+
+        // --- Compute repo health ---
+        const score = computeHealth(info);
+        const color = score > 75 ? "green" : score > 50 ? "yellow" : "red";
+
+        // --- Add row to table ---
+        tableBody.innerHTML += `
+            <tr>
+                <td>${repo}</td>
+                <td>${info.openPRs}</td>
+                <td>${info.gitleaks ? new Date(info.gitleaks).toLocaleString() : badge("red","None")}</td>
+                <td>${info.trivy ? new Date(info.trivy).toLocaleString() : badge("red","None")}</td>
+                <td>${info.lastCI ? new Date(info.lastCI).toLocaleString() : "—"}</td>
+                <td>${badge(color, score)}</td>
+            </tr>
+        `;
     }
+
 
     // Update dashboard
     document.getElementById("open-prs").innerText = totalOpenPRs;
     document.getElementById("ci-failures").innerText = totalFailures;
 
     // Placeholder values
-    document.getElementById("gitleaks-run").innerText = "Coming soon...";
-    document.getElementById("trivy-run").innerText = "Coming soon...";
-    document.getElementById("health-score").innerText = "Calculating...";
+    document.getElementById("gitleaks-run").innerText =
+        lastGitleaksDate ? lastGitleaksDate.toLocaleString() : "No runs found";
+
+    document.getElementById("trivy-run").innerText =
+        lastTrivyDate ? lastTrivyDate.toLocaleString() : "No runs found";
+    document.getElementById("health-score").innerText = Math.round(totalFailures === 0 ? 90 : 70);
 
     // Show UI
     document.getElementById("loading").style.display = "none";

--- a/docs/devops-dashboard/index.html
+++ b/docs/devops-dashboard/index.html
@@ -12,32 +12,37 @@
 <section id="loading">Loading data...</section>
 
 <section id="dashboard" style="display:none;">
+
+    <h2>Organization Summary</h2>
+
     <div class="card">
-        <h2>Total Open PRs</h2>
+        <h3>Total Open PRs</h3>
         <div id="open-prs">--</div>
     </div>
 
     <div class="card">
-        <h2>Failed CI Runs (last 7 days)</h2>
+        <h3>Total Failed CI Runs (last 50)</h3>
         <div id="ci-failures">--</div>
     </div>
 
     <div class="card">
-        <h2>Last Gitleaks Run</h2>
-        <div id="gitleaks-run">--</div>
-    </div>
-
-    <div class="card">
-        <h2>Last Trivy Run</h2>
-        <div id="trivy-run">--</div>
-    </div>
-
-    <div class="card">
-        <h2>Repo Health Score</h2>
+        <h3>Overall Health Score</h3>
         <div id="health-score">--</div>
     </div>
-</section>
 
-<script src="dashboard.js"></script>
-</body>
-</html>
+    <h2>Per-Repository Status</h2>
+
+    <table id="repo-table">
+        <thead>
+            <tr>
+                <th>Repository</th>
+                <th>Open PRs</th>
+                <th>Last Gitleaks</th>
+                <th>Last Trivy</th>
+                <th>Last CI</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</section>

--- a/docs/devops-dashboard/index.html
+++ b/docs/devops-dashboard/index.html
@@ -9,6 +9,14 @@
 
 <h1>Peer Network — DevOps Dashboard</h1>
 
+<p>
+    <a href="https://github.com/peer-network/.github/tree/main/devops-docs" 
+       target="_blank" 
+       class="nav-link">
+       📘 View DevOps Documentation Portal →
+    </a>
+</p>
+
 <section id="loading">Loading data...</section>
 
 <section id="dashboard" style="display:none;">
@@ -41,6 +49,7 @@
                 <th>Last Trivy</th>
                 <th>Last CI</th>
                 <th>Status</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody></tbody>

--- a/docs/devops-dashboard/style.css
+++ b/docs/devops-dashboard/style.css
@@ -70,3 +70,16 @@ table tr:hover {
 .badge.red {
     background-color: #e74c3c;
 }
+
+/* ---------- NAVIGATION LINK ---------- */
+
+.nav-link {
+    font-size: 16px;
+    font-weight: bold;
+    text-decoration: none;
+    color: #0077cc;
+}
+
+.nav-link:hover {
+    text-decoration: underline;
+}

--- a/docs/devops-dashboard/style.css
+++ b/docs/devops-dashboard/style.css
@@ -21,3 +21,52 @@ h1 {
   margin-top: 0;
 }
 
+/* ---------- TABLE ---------- */
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 0 8px rgba(0,0,0,0.1);
+}
+
+table th, table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+}
+
+table th {
+    background: #fafafa;
+    font-weight: bold;
+}
+
+table tr:hover {
+    background: #f9f9f9;
+}
+
+/* ---------- BADGES ---------- */
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 6px;
+    color: white;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+.badge.green {
+    background-color: #2ecc71;
+}
+
+.badge.yellow {
+    background-color: #f1c40f;
+    color: black;
+}
+
+.badge.red {
+    background-color: #e74c3c;
+}


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR introduces the first version of the Peer Network DevOps Dashboard.
The goal is to provide organization-wide visibility into CI activity across all repositories, including open PRs, recent workflow failures, and basic security scan history.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

A new static dashboard has been added under docs/devops-dashboard/ and published via GitHub Pages.
It pulls public GitHub API data to display total open PRs, CI failures, and a per-repository status table including last Gitleaks/Trivy runs and a simple health score.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added index.html, style.css, and dashboard.js (static dashboard)

Added a table view and health score logic

Integrated the dashboard into GitHub Pages under /docs/devops-dashboard/

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
