### PR TITLE
edited to now find gitlesks trivy either workflow or job

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=./devops-dashboard/" />
+</head>
+<body>
+  <p>Redirecting to DevOps Dashboard…</p>
+</body>
+</html>


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

The DevOps dashboard was not correctly detecting recent Gitleaks and Trivy runs across Peer Network repositories. GitHub API only exposes workflow run metadata, not individual job details, causing the dashboard to display None for both security checks even when they were executed successfully. Also Added health score

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Added a GitHub Actions job-scraping helper that queries the /jobs API for each workflow run and extracts timestamps for Gitleaks and Trivy. The dashboard now loops through multiple recent runs and returns the most recent valid occurrence of each job. This fixes incorrect “None” values for security scan timestamps across backend, frontend, and global repos.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added findJob() utility for per-run job discovery

Updated workflow run parsing logic to scan multiple runs

Replaced string-search heuristics with job-level detection

Updated dashboard rendering to show actual timestamps for security jobs

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
