### PR TITLE
modified to tag leads

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -42,9 +42,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Determine Team Lead
+        id: teamlead
+        run: |
+          case "${{ inputs.repo_name }}" in
+            "Web Frontend")
+              echo "lead=<@1367037547011641407>" >> $GITHUB_OUTPUT
+              ;;
+            "Android Frontend")
+              echo "lead=<@1354048093376610366>" >> $GITHUB_OUTPUT
+              ;;
+            "iOS Frontend")
+              echo "lead=<@310723093863858176>" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "lead=" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
       - name: Build message
         id: build
         run: |
+          LEAD="${{ steps.teamlead.outputs.lead }}"
+
           case "${{ inputs.event_type }}" in
 
             behind)
@@ -92,7 +112,14 @@ jobs:
               MESSAGE+="\n\n**PR:** ${{ inputs.pr_title }}"
               MESSAGE+="\nPR Link: <${{ inputs.pr_url }}>"
               MESSAGE+="\nCI Run: <${{ inputs.run_url }}>"
-              MESSAGE+="\n\nAll checks passed successfully. Great work ${{ inputs.discord_mention }} 🎉"
+              MESSAGE+="\n\nAll checks passed successfully."
+
+              # Append team lead if available
+              if [ -n "$LEAD" ]; then
+                MESSAGE+=" $LEAD"
+              else
+                MESSAGE+=" Great work ${{ inputs.discord_mention }}"
+              fi
               ;;
 
             *)


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This update improves CI notifications by ensuring the correct team leads are automatically tagged on successful pipeline runs. This helps visibility, ownership, and faster follow-ups across frontend teams.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Added a reusable workflow enhancement that maps each repository to its designated team lead. On a successful CI run, the notification now tags the correct lead instead of the PR author. No behavior changes for failure events.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added team-lead detection logic in the reusable Discord notification workflow.

Updated success message formatting to include the mapped team lead.

Standardized repo name patterns used across all CI workflows.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
