### PR TITLE
added auto label for ci

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,86 @@
+name: Auto-Label PR
+
+on:
+  workflow_call:
+    inputs:
+      label_config:
+        description: "JSON map of patterns to labels"
+        type: string
+        required: true
+      mode:
+        description: "soft or hard"
+        type: string
+        default: "soft"
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  autolabel:
+    name: Apply Auto-Labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          separator: ","
+
+      - name: Parse config
+        id: cfg
+        run: |
+          echo "config<<EOF" >> $GITHUB_OUTPUT
+          echo '${{ inputs.label_config }}' | jq '.' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Match patterns
+        id: match
+        run: |
+          files="${{ steps.changed.outputs.all_modified_files }}"
+          echo "Changed files: $files"
+
+          labels=()
+
+          # loop through config
+          for pattern in $(echo "${{ steps.cfg.outputs.config }}" | jq -r 'keys[]'); do
+            label=$(echo "${{ steps.cfg.outputs.config }}" | jq -r --arg p "$pattern" '.[$p]')
+
+            echo "$files" | tr "," "\n" | grep -E "$pattern" >/dev/null 2>&1
+            if [ $? -eq 0 ]; then
+              echo "Matched $pattern → $label"
+              labels+=("$label")
+            fi
+          done
+
+          printf '%s\n' "${labels[@]}" | jq -R . | jq -s . | tee labels.json
+          echo "labels=$(cat labels.json)" >> $GITHUB_OUTPUT
+
+      - name: Apply labels
+        if: steps.match.outputs.labels != '[]'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const labels = ${{ steps.match.outputs.labels }};
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels,
+            });
+
+      - name: Hard mode check
+        if: inputs.mode == 'hard'
+        run: |
+          if [[ "${{ steps.match.outputs.labels }}" == "[]" ]]; then
+            echo "::error ::Hard mode enabled but no labels matched."
+            exit 1
+          fi


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

Adds an organization-wide reusable workflow for automatic PR labeling based on file changes.
This improves triaging, review routing, and CI efficiency across all Peer Network repositories.
Labels are now consistently applied without manual intervention.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Introduced a new reusable workflow auto-label.yml that:

Detects changed files via tj-actions/changed-files

Matches file paths against a configurable pattern → label map

Applies labels automatically using actions/github-script@v8

Supports soft (non-blocking) and hard (strict) modes
This workflow can now be called from any repository’s CI pipeline.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added .github/workflows/auto-label.yml

Implements dynamic label matching and application

Prepares base functionality for future enhancements (auto-reviewers, summaries, etc.)

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

No breaking changes.
Repos must explicitly import this reusable workflow to enable auto-labeling.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
