### PR TITLE
replace heredoc with safe printf JSON parsing

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Parse config
         id: cfg
         run: |
-          echo "config<<EOF" >> $GITHUB_OUTPUT
-          echo "${{ inputs.label_config }}" | jq . >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          printf "%s\n" "${{ inputs.label_config }}" > config.json
+          jq . config.json > parsed.json
+          echo "config=$(cat parsed.json)" >> $GITHUB_OUTPUT
 
       - name: Match patterns
         id: match


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

Auto-labeling failed due to a jq parse error caused by heredoc formatting issues when passing JSON from the workflow inputs. This prevented the reusable workflow from running correctly across repos.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Replaced the heredoc-based JSON parsing with a safe printf approach to write the label_config input into config.json. This ensures valid JSON reaches jq and fixes the workflow failure.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->
Updated auto-label.yml to use printf for JSON input.

Removed heredoc to eliminate YAML/indentation parsing issues.

Ensured stable output to GITHUB_OUTPUT.


### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
