### PR TITLE
changed jq in PR extract

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Extract PR info
         id: refs
         run: |
-          PR='${{ inputs.pull_request }}'
-          echo "base=$(echo "$PR" | jq -r '.base.ref')" >> $GITHUB_OUTPUT
-          echo "head=$(echo "$PR" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-          echo "number=$(echo "$PR" | jq -r '.number')" >> $GITHUB_OUTPUT
+          echo '${{ inputs.pull_request }}' > pr.json
+          echo "base=$(jq -r '.base.ref' pr.json)" >> $GITHUB_OUTPUT
+          echo "head=$(jq -r '.head.ref' pr.json)" >> $GITHUB_OUTPUT
+          echo "number=$(jq -r '.number' pr.json)" >> $GITHUB_OUTPUT
 
       - name: Fetch all refs
         run: git fetch origin


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

The reusable workflow for auto-updating PR branches was failing early because the pull_request input JSON could not be parsed correctly.
GitHub Actions treats multiline YAML strings differently, so expressions inside {} were not being evaluated, and the workflow could not extract the base, head, and number fields.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

This PR fixes the extraction step by writing the raw JSON input into a temporary pr.json file and using jq to safely read the values.
This ensures stable and correct parsing of the workflow inputs in all repos that reuse this action.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->



### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
