### PR TITLE
moved permissions before event

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -1,5 +1,9 @@
 name: Auto Update PR Branch
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_call:
     inputs:
@@ -11,10 +15,6 @@ jobs:
   auto_update:
     name: Auto-update PR if behind
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

To ensure the reusable workflow has the correct GitHub Actions permissions at startup, the permissions block was moved above the workflow_call event. This aligns with GitHub’s required structure, prevents startup failures, and allows the workflow to push updates to PR branches.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The contents: write and pull-requests: write permissions were relocated from inside the job to the top-level of the reusable workflow. This guarantees the workflow has the necessary rights before execution and allows successful branch auto-updates triggered by calling workflows.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->



### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
