### PR TITLE
converted to use base 64

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -29,8 +29,12 @@ jobs:
         run: |
           # CASE 1: Workflow was called from pull_request
           if [ -n "${{ inputs.pull_request }}" ] && [ "${{ inputs.pull_request }}" != "null" ]; then
-            echo "${{ inputs.pull_request }}" > pr.json
 
+            # Encode JSON safely using base64
+            echo "${{ toJson(inputs.pull_request) }}" | base64 -w0 > pr.b64
+
+            # Decode safely into a proper JSON file
+            base64 -d pr.b64 > pr.json
 
             BASE=$(jq -r '.base.ref' pr.json)
             HEAD=$(jq -r '.head.ref' pr.json)


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR fixes the auto-update workflow by adding a safe and reliable way to handle PR JSON data. The previous approach failed due to YAML parsing issues when raw JSON was passed directly into bash. This update ensures consistent auto-update behavior across all frontend repos.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The workflow now encodes the incoming PR payload using toJson + base64 to avoid YAML interpolation problems, then decodes it safely inside the bash step. This allows correct extraction of .base.ref and .head.ref for merge checks. No functional changes outside the CI pipeline.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added base64 encode/decode logic for PR JSON

Updated ref-determination logic for PR and non-PR workflows

Improved workflow stability and compatibility with GitHub Actions

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
