### PR TITLE
jq install step deleted

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -19,9 +19,6 @@ jobs:
     name: Auto-update PR if behind
     runs-on: ubuntu-latest
     steps:
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Checkout repo
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

The reusable auto-update workflow now expects explicit pr_base and pr_head inputs instead of raw PR JSON.
Without passing these values, Android CI could not determine the correct branches to auto-update, causing failures on PR events.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Updated the CI workflow to provide pr_base and pr_head only when the workflow is triggered by a pull_request event.
This ensures the auto-update logic can correctly detect outdated branches and apply updates safely.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

pr_base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
pr_head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
No application code changes.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This change improves CI reliability and prevents errors caused by missing or malformed PR metadata.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
