### PR TITLE
Check branch reusable

### DIFF
--- a/.github/workflows/check-branch-sync.yml
+++ b/.github/workflows/check-branch-sync.yml
@@ -1,0 +1,47 @@
+name: Check Branch Sync
+
+on:
+  workflow_call:
+    inputs:
+      base_branch:
+        required: true
+        type: string
+      pr_branch:
+        required: true
+        type: string
+
+    outputs:
+      is_behind:
+        value: ${{ jobs.check.outputs.is_behind }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_behind: ${{ steps.check.outputs.is_behind }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all branches
+        run: |
+          git fetch origin +refs/heads/*:refs/remotes/origin/*
+
+      - name: Compare PR branch with base
+        id: check
+        run: |
+          base="${{ inputs.base_branch }}"
+          head="${{ inputs.pr_branch }}"
+
+          echo "Comparing $head against $base"
+
+          behind=$(git rev-list --left-right --count origin/$base...origin/$head | awk '{print $1}')
+
+          if [ "$behind" -gt 0 ]; then
+            echo "is_behind=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_behind=false" >> $GITHUB_OUTPUT
+          fi


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR introduces a reusable workflow to standardize branch sync checks across all Peer repositories. The goal is to ensure PR branches are always compared reliably against their base branches, reducing CI failures caused by outdated code.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

A new check-branch-sync reusable workflow was added. It accepts the base and PR branch names as inputs, performs a full git rev-list comparison, and outputs whether the PR is behind. Other repos can now call this workflow directly instead of duplicating logic.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added check-branch-sync.yml reusable workflow
Implemented consistent behind-branch detection using git rev-list
Exposed is_behind output for use in caller workflows

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This workflow does not modify any existing CI logic; it only centralizes and standardizes the sync check for easier maintenance.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
