### PR TITLE
Added message about merge conflicts

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -67,6 +67,16 @@ jobs:
 
           case "${{ inputs.event_type }}" in
 
+            auto_update_conflict)
+              MESSAGE=":warning: **${{ inputs.repo_name }} Auto-Update Failed Due to Merge Conflict**"
+              MESSAGE+="\n\n**PR:** ${{ inputs.pr_title }}"
+              MESSAGE+="\nPR Link: <${{ inputs.pr_url }}>"
+              MESSAGE+="\nCI Run: <${{ inputs.run_url }}>"
+              MESSAGE+="\nAuthor: ${{ inputs.discord_mention }}"
+              MESSAGE+="\nYou can resolve the conflicts **locally** or use GitHub's **Resolve conflicts** button."
+              MESSAGE+="\nAfter fixing the conflicts, push or commit the changes and the CI will retry automatically."
+              ;;
+
             behind)
               MESSAGE=":warning: **${{ inputs.repo_name }} PR Branch is Behind the Base Branch**"
               MESSAGE+="\n\n**PR:** ${{ inputs.pr_title }}"


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

To improve CI clarity and ensure contributors immediately understand why auto-update failed, we added a dedicated Discord notification message specifically for merge-conflict scenarios in the reusable notification workflow.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

A new auto_update_conflict event type was introduced to the reusable Discord notification workflow. When the auto-update job cannot merge the base branch due to conflicts, CI now triggers a clear message instructing the author to resolve conflicts either locally or via GitHub’s “Resolve conflicts” UI.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added new auto_update_conflict case in the reusable Discord message builder.
Added conflict-specific text explaining next steps to contributors.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This improves contributor experience and ensures merge conflicts are visible immediately to both authors and team leads.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
