### PR TITLE
Added ouputs so message can be sent on discord if conflict found

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -13,11 +13,19 @@ on:
       pr_head:
         required: false
         type: string
+    outputs:
+      auto_update_conflict:
+        value: ${{ jobs.auto_update.outputs.auto_update_conflict }}
+      auto_update_status:
+        value: ${{ jobs.auto_update.outputs.auto_update_status }}
 
 jobs:
   auto_update:
     name: Auto-update PR if behind
     runs-on: ubuntu-latest
+    outputs:
+      auto_update_conflict: ${{ steps.mergecheck.outputs.conflict }}
+      auto_update_status: ${{ steps.status.outputs.status }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -58,6 +66,11 @@ jobs:
         if: steps.behind.outputs.behind == '0'
         run: echo "Branch is up to date."
 
+      - name: Default conflict output when up to date
+        id: mergecheck
+        if: steps.behind.outputs.behind == '0'
+        run: echo "conflict=false" >> $GITHUB_OUTPUT
+
       - name: Try merge (check conflicts)
         id: mergecheck
         if: steps.behind.outputs.behind != '0'
@@ -80,6 +93,15 @@ jobs:
       - name: Stop on conflicting merge
         if: ${{ steps.mergecheck.outputs.conflict == 'true' }}
         run: echo "Merge conflict detected — cannot auto-update."
+
+      - name: Set auto-update status
+        id: status
+        run: |
+          if [ "${{ steps.mergecheck.outputs.conflict }}" == "true" ]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit and push merge
         if: ${{ steps.mergecheck.outputs.conflict == 'false' }}


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This improves the auto-update mechanism used across all frontend and backend repositories. Previously, the workflow could detect merge conflicts but did not expose this information to calling workflows in a structured way, making it impossible to trigger conflict-specific CI logic or Discord notifications.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

A new output structure was added to the auto-update-pr reusable workflow to report whether an auto-update attempt resulted in a merge conflict and whether it succeeded or failed. These outputs (auto_update_conflict and auto_update_status) can now be consumed by the parent workflows to display accurate Discord notifications and handle conflict scenarios more gracefully.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added auto_update_conflict and auto_update_status as workflow_call outputs.
Added logic to set status=success|failure depending on merge outcome.
Ensured a default conflict output is generated for up-to-date branches.
Updated merge-check step to expose conflict status consistently.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This enables the CI to send clear Discord messages when auto-update fails due to conflicts and improves visibility for developers.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
