### PR TITLE
improved to exclude workflows

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -71,6 +71,11 @@ jobs:
         if: steps.behind.outputs.behind == '0'
         run: echo "conflict=false" >> $GITHUB_OUTPUT
 
+      - name: Default workflow change output when up to date
+        if: steps.behind.outputs.behind == '0'
+        run: echo "workflow_changes=false" >> $GITHUB_OUTPUT
+        id: detect_workflows_default
+
       - name: Try merge (check conflicts)
         id: mergecheck
         if: steps.behind.outputs.behind != '0'
@@ -90,6 +95,21 @@ jobs:
             echo "conflict=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Detect workflow file changes
+        id: detect_workflows
+        if: ${{ steps.mergecheck.outputs.conflict == 'false' && steps.behind.outputs.behind != '0' }}
+        run: |
+          if git diff --name-only --cached | grep -q '^\.github/workflows/'; then
+            echo "workflow_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "workflow_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Abort merge if workflow files changed
+        if: ${{ steps.detect_workflows.outputs.workflow_changes == 'true' }}
+        run: |
+          git merge --abort || git reset --hard
+
       - name: Stop on conflicting merge
         if: ${{ steps.mergecheck.outputs.conflict == 'true' }}
         run: echo "Merge conflict detected — cannot auto-update."
@@ -97,14 +117,22 @@ jobs:
       - name: Set auto-update status
         id: status
         run: |
+          WORKFLOW_CHANGED="${{ steps.detect_workflows.outputs.workflow_changes || steps.detect_workflows_default.outputs.workflow_changes }}"
+
           if [ "${{ steps.mergecheck.outputs.conflict }}" == "true" ]; then
             echo "status=failure" >> $GITHUB_OUTPUT
+          elif [ "$WORKFLOW_CHANGED" == "true" ]; then
+            echo "status=skipped_workflows" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.behind.outputs.behind }}" == "0" ]; then
+            echo "status=up_to_date" >> $GITHUB_OUTPUT
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
 
       - name: Commit and push merge
-        if: ${{ steps.mergecheck.outputs.conflict == 'false' }}
+        if: |
+          steps.mergecheck.outputs.conflict == 'false' &&
+          (steps.detect_workflows.outputs.workflow_changes || steps.detect_workflows_default.outputs.workflow_changes) != 'true'
         run: |
           git commit -m "Auto-update branch from ${{ steps.determine.outputs.base }}"
           git push origin HEAD


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

Auto-update PRs were failing when the merge touched workflow files due to GitHub security restrictions. This caused unnecessary CI failures even though the merge itself was valid. The goal is to make auto-updates safe, predictable, and compliant with GitHub’s permission model.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The auto-update reusable workflow was updated to detect changes under .github/workflows/** after a merge. If workflow files are affected, the merge is aborted and the auto-update is skipped instead of failing. Normal merges continue to auto-commit and push as before, with clear status outputs (success, failure, skipped_workflows, up_to_date).

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added workflow-file change detection after merge
Guarded commit/push to avoid workflow updates
Improved status reporting for skipped and up-to-date cases

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This avoids permission escalation (no PAT required) and aligns with GitHub’s security model for GitHub App tokens.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
