### PR TITLE
Harden reusable auto-label workflow with input validation and deduplication

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -25,9 +25,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Get changed files
         id: changed
         uses: tj-actions/changed-files@v45
@@ -38,6 +35,10 @@ jobs:
         id: cfg
         run: |
           echo "${{ inputs.label_config }}" > config.json
+          jq empty config.json || {
+            echo "::error ::Invalid label_config JSON"
+            exit 1
+          }
           jq . config.json > parsed.json
           echo "config=$(cat parsed.json)" >> $GITHUB_OUTPUT
 
@@ -60,7 +61,7 @@ jobs:
             fi
           done
 
-          printf '%s\n' "${labels[@]}" | jq -R . | jq -s . | tee labels.json
+          printf '%s\n' "${labels[@]}" | sort -u | jq -R . | jq -s . | tee labels.json
           echo "labels=$(cat labels.json)" >> $GITHUB_OUTPUT
 
       - name: Apply labels


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This change improves the robustness and reliability of the reusable Auto-Label PR workflow used across Peer repositories.
Previously, the workflow assumed valid JSON input and allowed duplicate label emission, which could lead to silent misconfiguration or unnecessary API calls.
The goal of this update is to harden the workflow against invalid inputs while keeping behavior fully backward-compatible.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The reusable auto-label workflow was enhanced with defensive validation and output sanitization:
Added fail-fast JSON validation for the label_config input using jq empty, ensuring invalid configurations fail clearly and early.
Removed unnecessary repository checkout to reduce execution time and permissions surface.
Added label deduplication before applying labels to prevent redundant API calls when multiple patterns map to the same label.
Preserved existing soft vs hard mode behavior with no functional change to consumers.
No changes were made to label matching logic, regex behavior, or calling workflows.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Reusable workflow hardening:
Input validation with explicit error messaging
Sorted & deduplicated label output
Removed unused actions/checkout
Affected file:
.github/workflows/auto-label.yml

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This change is non-breaking for all existing consumers.
Behavior remains identical for valid configurations.
Misconfigured inputs now fail deterministically instead of silently.
No rollout or rollback steps required.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
