### PR TITLE
fixed json

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -34,11 +34,15 @@ jobs:
       - name: Parse config
         id: cfg
         run: |
-          echo "${{ inputs.label_config }}" > config.json
+          cat <<'EOF' > config.json
+          ${{ inputs.label_config }}
+          EOF
+
           jq empty config.json || {
             echo "::error ::Invalid label_config JSON"
             exit 1
           }
+
           jq . config.json > parsed.json
           echo "config=$(cat parsed.json)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR fixes a failure in the reusable Auto-Label PR workflow when consuming multiline JSON inputs from calling workflows.
The previous implementation used shell echo, which could corrupt multiline input and cause JSON parsing errors at runtime.
The goal of this change is to ensure reliable handling and validation of label configuration inputs across all repositories using this workflow.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The reusable auto-label workflow was updated to safely write the label_config input to disk using a heredoc, preserving the input exactly as provided.
This ensures that multiline JSON passed from calling workflows is not altered by shell interpolation or newline handling.
The workflow continues to validate the configuration using jq and fails fast with a clear error message if the input is invalid.
No behavior changes were introduced for valid configurations, and no calling workflows require modification.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Updated reusable workflow to write label_config via a quoted heredoc instead of echo
Preserved existing JSON validation using jq
No changes to label matching logic, permissions, or job dependencies

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
