### PR TITLE
safely handle multiline label_config in auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -43,8 +43,8 @@ jobs:
             exit 1
           }
 
-          jq . config.json > parsed.json
-          echo "config=$(cat parsed.json)" >> $GITHUB_OUTPUT
+          config=$(jq -c . config.json)
+          echo "config=$config" >> "$GITHUB_OUTPUT"
 
       - name: Match patterns
         id: match
@@ -65,8 +65,8 @@ jobs:
             fi
           done
 
-          printf '%s\n' "${labels[@]}" | sort -u | jq -R . | jq -s . | tee labels.json
-          echo "labels=$(cat labels.json)" >> $GITHUB_OUTPUT
+          labels_json=$(printf '%s\n' "${labels[@]}" | sort -u | jq -R . | jq -s -c .)
+          echo "labels=$labels_json" >> "$GITHUB_OUTPUT" 
 
       - name: Apply labels
         if: steps.match.outputs.labels != '[]'


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR fixes a failure in the reusable auto-label workflow caused by multiline JSON inputs and GitHub Actions output formatting constraints. The issue surfaced when passing repository-specific label mappings into the workflow.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The auto-label reusable workflow was hardened to safely handle multiline label_config inputs and to emit only compact, single-line JSON to $GITHUB_OUTPUT. This prevents parsing errors and ensures labels are applied reliably across all consuming repositories.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

safely write label_config to disk before parsing
Validate and compact JSON using jq -c
Prevent multiline output values in GitHub Actions

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
