### PR TITLE
correctly parse label_config and apply auto-labels

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -55,8 +55,8 @@ jobs:
           labels=()
 
           # loop through config
-          for pattern in $(echo "${{ steps.cfg.outputs.config }}" | jq -r 'keys[]'); do
-            label=$(echo "${{ steps.cfg.outputs.config }}" | jq -r --arg p "$pattern" '.[$p]')
+          for pattern in $(jq -r 'keys[]' config.json); do
+            label=$(jq -r --arg p "$pattern" '.[$p]' config.json)
 
             echo "$files" | tr "," "\n" | grep -E "$pattern" >/dev/null 2>&1
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

Fixes a failure in the reusable auto-label workflow caused by how label configuration JSON was parsed and passed through GitHub Actions.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The auto-label workflow now safely reads and parses the label configuration from disk and emits only compact, single-line JSON outputs, ensuring labels are applied reliably.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Safely write and validate label_config
Fix label matching to avoid empty or invalid labels

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
