### PR TITLE
skip when theres no label in the code

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -64,8 +64,17 @@ jobs:
             fi
           done
 
-          labels_json=$(printf '%s\n' "${labels[@]}" | sort -u | jq -R . | jq -s -c .)
-          echo "labels=$labels_json" >> "$GITHUB_OUTPUT" 
+          if [ "${#labels[@]}" -eq 0 ]; then
+            labels_json="[]"
+          else
+            labels_json=$(printf '%s\n' "${labels[@]}" \
+              | sed '/^$/d' \
+              | sort -u \
+              | jq -R . \
+              | jq -s -c .)
+            fi
+
+            echo "labels=$labels_json" >> "$GITHUB_OUTPUT"
 
       - name: Apply labels
         if: steps.match.outputs.labels != '[]'
@@ -73,7 +82,13 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-            const labels = ${{ steps.match.outputs.labels }};
+            const labels = ${{ steps.match.outputs.labels }}.filter(Boolean);
+
+            if (labels.length === 0) {
+              console.log("No labels to apply — skipping");
+              return;
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR fixes a failure in the reusable auto labeling workflow where pull requests with no matching label rules caused the workflow to fail.
When no patterns matched, the workflow attempted to apply an empty label (""), which GitHub rejects with a 422 validation error.
This resulted in unnecessary CI failures, especially in soft mode, even though the behavior was logically valid.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

The auto-label reusable workflow was hardened to correctly handle cases where no labels match changed files.
Key changes:
Ensured the label resolution step outputs a proper empty JSON array ([]) when no labels are matched.
Added defensive filtering in the GitHub API call to prevent empty or invalid labels from being sent.
Preserved existing soft vs hard mode behavior:
Soft mode skips labeling gracefully.
Hard mode still fails if no labels are matched.
This prevents invalid GitHub API calls while keeping current enforcement semantics intact.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Updated label aggregation logic to avoid producing [""] when no labels are detected
Added a final guard in actions/github-script to filter empty values before applying labels
No changes to label rules, permissions, or calling workflows

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This is a defensive fix with no behavioral impact on valid label matches
Prevents CI noise and false failures in repositories using centralized auto-labeling
Safe for reuse across all Peer development repositories

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
